### PR TITLE
make dv names consistent with other t-tests

### DIFF
--- a/inst/help/EquivalenceBayesianIndependentSamplesTTest.md
+++ b/inst/help/EquivalenceBayesianIndependentSamplesTTest.md
@@ -14,7 +14,7 @@ The equivalence independent samples t-test allows the user to test the null hypo
 ---
 
 #### Assignment Box
-- Variables: In this box the dependent variable is selected.
+- Dependent Variables: In this box the dependent variable is selected.
 - Grouping Variable: In this box the variable defining the groups is selected.
 
 #### Equivalence region

--- a/inst/help/EquivalenceBayesianIndependentSamplesTTest_nl.md
+++ b/inst/help/EquivalenceBayesianIndependentSamplesTTest_nl.md
@@ -14,7 +14,7 @@ Met de gelijkwaardigheids t-toets voor onafhankelijke steekproeven kan de gebrui
 ---
 
 #### Invul veld
-- Variabelen: In deze box wordt de afhankelijke variabele geselecteerd.
+- Afhankelijke Variabelen: In deze box wordt de afhankelijke variabele geselecteerd.
 - Groeperende Variabele: In deze box wordt de variabele die de groepen definieert geselecteerd.
 
 #### Gelijkwaardigheids regio

--- a/inst/help/EquivalenceBayesianPairedSamplesTTest.md
+++ b/inst/help/EquivalenceBayesianPairedSamplesTTest.md
@@ -12,7 +12,7 @@ The equivalence paired samples t-test allows the user to test the null hypothesi
 ---
 
 #### Assignment Box
-- Variables: In this box the variables are selected for which the difference is computed. Multiple differences can be analysed at the same time by specifying different rows with two variables for which the difference is computed. In other words, each row represents other difference scores.
+- Variable Pairs: In this box the variables are selected for which the difference is computed. Multiple differences can be analysed at the same time by specifying different rows with two variables for which the difference is computed. In other words, each row represents other difference scores.
 
 #### Equivalence region
 - from ... to ... : Defines the equivalence region by specifying the lower bound and the upper bound.

--- a/inst/help/EquivalenceBayesianPairedSamplesTTest_nl.md
+++ b/inst/help/EquivalenceBayesianPairedSamplesTTest_nl.md
@@ -12,7 +12,7 @@ Met de gelijkwaardigheids Beyeisaanse gepaarde t-toets kan de gebruiker de nulhy
 ---
 
 #### Invoerveld
-- Variabelen: In deze box zijn de variabelen geselecteerd waarvoor het verschil is berekend. Meerdere verschillen kunnen tegelijkertijd worden geanalyseerd door het specificeren van verschillende rijen met twee variabelen waarvoor het verschil is berekend. Met andere woorden, iedere rij geeft andere verschilscores weer.
+- Variabele Paren: In deze box zijn de variabelen geselecteerd waarvoor het verschil is berekend. Meerdere verschillen kunnen tegelijkertijd worden geanalyseerd door het specificeren van verschillende rijen met twee variabelen waarvoor het verschil is berekend. Met andere woorden, iedere rij geeft andere verschilscores weer.
 
 #### Gelijkwaardigheids regio
 - van ... tot ... : Bepaalt de gelijkwaardigheids regio door de boven- en ondergrens te specificeren.

--- a/inst/help/EquivalencePairedSamplesTTest.md
+++ b/inst/help/EquivalencePairedSamplesTTest.md
@@ -11,7 +11,7 @@ The equivalence paired samples t-test allows the user to test the null hypothesi
 ### Input
 -------
 #### Assignment Box
-- Variables: In this box the variables are selected for which the difference is computed. Multiple differences can be analysed at the same time by specifying different rows with two variables for which the difference is computed. In other words, each row represents other difference scores.
+- Variable Pairs: In this box the variables are selected for which the difference is computed. Multiple differences can be analysed at the same time by specifying different rows with two variables for which the difference is computed. In other words, each row represents other difference scores.
 
 #### Equivalence region
 - Upper bound: The upper bound of the equivalence region.

--- a/inst/help/EquivalencePairedSamplesTTest_nl.md
+++ b/inst/help/EquivalencePairedSamplesTTest_nl.md
@@ -11,7 +11,7 @@ Met de gelijkwaardigheids gepaarde t-toets kan de gebruiker de nul hypothese toe
 ### Invoer
 -------
 #### Invoerveld
-- Variabelen: In deze box zijn de variabelen geselecteerd waarvoor het verschil is berekend. Meerdere verschillen kunnen tegelijkertijd worden geanalyseerd door het specificeren van verschillende rijen met twee variabelen waarvoor het verschil is berekend. Met andere woorden, iedere rij geeft andere verschilscores weer.
+- Variabele Paren: In deze box zijn de variabelen geselecteerd waarvoor het verschil is berekend. Meerdere verschillen kunnen tegelijkertijd worden geanalyseerd door het specificeren van verschillende rijen met twee variabelen waarvoor het verschil is berekend. Met andere woorden, iedere rij geeft andere verschilscores weer.
 
 #### Gelijkwaardigheids regio
 - Bovengrens: De bovengrens van de gelijkswaardigheids regio.

--- a/inst/qml/EquivalenceBayesianIndependentSamplesTTest.qml
+++ b/inst/qml/EquivalenceBayesianIndependentSamplesTTest.qml
@@ -31,7 +31,7 @@ Form
     {
 		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
         AvailableVariablesList { name: "allVariablesList" }
-		AssignedVariablesList  { name: "variables";			title: qsTr("Variables");			allowedColumns: ["scale"]	}
+		AssignedVariablesList  { name: "variables";			title: qsTr("Dependent Variables");			allowedColumns: ["scale"]	}
 		AssignedVariablesList  { name: "groupingVariable";	title: qsTr("Grouping Variable");	allowedColumns: ["nominal"]; singleVariable: true}
     }
 

--- a/inst/qml/EquivalenceBayesianPairedSamplesTTest.qml
+++ b/inst/qml/EquivalenceBayesianPairedSamplesTTest.qml
@@ -31,7 +31,7 @@ Form
     {
 		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
         AvailableVariablesList { name: "allVariablesList" }
-		AssignedPairsVariablesList { name: "pairs"; title: qsTr("Variable pairs"); allowedColumns: ["scale"] }
+		AssignedPairsVariablesList { name: "pairs"; title: qsTr("Variable Pairs"); allowedColumns: ["scale"] }
     }
 
     RadioButtonGroup

--- a/inst/qml/EquivalenceIndependentSamplesTTest.qml
+++ b/inst/qml/EquivalenceIndependentSamplesTTest.qml
@@ -31,7 +31,7 @@ Form
     {
 		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
         AvailableVariablesList { name: "allVariablesList" }
-		AssignedVariablesList { name: "variables";			title: qsTr("Variables");			allowedColumns: ["scale"]	}
+		AssignedVariablesList { name: "variables";			title: qsTr("Dependent Variables");			allowedColumns: ["scale"]	}
 		AssignedVariablesList { name: "groupingVariable";	title: qsTr("Grouping Variable");	allowedColumns: ["nominal"]; singleVariable: true}
     }
 

--- a/inst/qml/EquivalencePairedSamplesTTest.qml
+++ b/inst/qml/EquivalencePairedSamplesTTest.qml
@@ -31,7 +31,7 @@ Form
     {
 		preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
         AvailableVariablesList { name: "allVariablesList" }
-		AssignedPairsVariablesList { name: "pairs"; title: qsTr("Variable pairs"); allowedColumns: ["scale"] }
+		AssignedPairsVariablesList { name: "pairs"; title: qsTr("Variable Pairs"); allowedColumns: ["scale"] }
     }
 
     Group


### PR DESCRIPTION
Fix https://github.com/jasp-stats/INTERNAL-jasp/issues/848

"Dependent Variables" in independent t-tests

"Variable Pairs" in paired t-tests